### PR TITLE
feat: add home::symlinks() for claude skills

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,6 +2,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 permissions:
@@ -13,9 +16,9 @@ jobs:
   claude-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip on merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping review in merge queue context"
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping review in queue context"
       - name: Run claude review
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
         continue-on-error: true

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -2,6 +2,9 @@ name: Codex Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 permissions:
@@ -13,9 +16,9 @@ jobs:
   codex-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip on merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping review in merge queue context"
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping review in queue context"
       - name: Run codex review
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
         continue-on-error: true

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,6 +9,9 @@ on:
       - reopened
       - ready_for_review
       - edited
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 jobs:

--- a/init.zsh
+++ b/init.zsh
@@ -31,6 +31,22 @@ p6df::modules::jenkins::vscodes() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::jenkins::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
+p6df::modules::jenkins::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/jenkinsfile-generator"            "$HOME/.claude/skills/jenkinsfile-generator"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/jenkinsfile-validator"            "$HOME/.claude/skills/jenkinsfile-validator"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::jenkins::langs()
 #
 #>


### PR DESCRIPTION
## Summary

- Adds `home::symlinks()` function to symlink Claude Code skills into `~/.claude/skills/`

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)