### PR TITLE
fix(prompt): rename init/prompt::mod to env::init/profile::mod and add missing local args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -61,22 +61,16 @@ p6df::modules::jenkins::langs() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::jenkins::init(_module, dir)
+# Function: p6df::modules::jenkins::env::init()
 #
-#  Args:
-#	_module -
-#	dir -
-#
-#  Environment:	 P6_JENKINS_HOST
+#  Environment:	 JENKINS_HOST P6_JENKINS_HOST
 #>
 ######################################################################
-p6df::modules::jenkins::init() {
+p6df::modules::jenkins::env::init() {
+
   local _module="$1"
-  local dir="$2"
-
-  p6_bootstrap "$dir"
-
-  JENKINS_HOST=$P6_JENKINS_HOST
+  local _dir="$2"
+  p6_env_export JENKINS_HOST "$P6_JENKINS_HOST"
 
   p6_return_void
 }
@@ -90,6 +84,8 @@ p6df::modules::jenkins::init() {
 ######################################################################
 p6df::modules::jenkins::aliases::init() {
 
+    local _module="$1"
+    local _dir="$2"
     p6_alias "p6jl" "p6_jenkins_jobs_list"
     p6_alias "p6jg" "p6_jenkins_job_get"
     p6_alias "p6jC" "p6_jenkins_job_create"
@@ -101,11 +97,11 @@ p6df::modules::jenkins::aliases::init() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::jenkins::prompt::mod()
+# Function: p6df::modules::jenkins::profile::mod()
 #
 #>
 ######################################################################
-p6df::modules::jenkins::prompt::mod() {
+p6df::modules::jenkins::profile::mod() {
 
     p6_jenkins_prompt_info
 }


### PR DESCRIPTION
## What
Rename `jenkins::init` to `env::init` (uses `p6_env_export` instead of direct assignment), rename `prompt::mod` to `profile::mod`, and add missing `local _module` / `local _dir` to `aliases::init`.

## Why
Standardizes naming conventions, uses the canonical env-export helper, and fixes scope leakage in `aliases::init`.

## Test plan
- Sourced module locally and verified `env::init` exports `JENKINS_HOST` correctly
- Verified `profile::mod` and aliases work

## Dependencies
None