### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::deps()
-#
-#>
-######################################################################
 p6df::modules::jenkins::deps() {
     ModuleDeps=(
         p6m7g8-dotfiles/p6df-java
@@ -13,58 +7,6 @@ p6df::modules::jenkins::deps() {
     )
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::vscodes()
-#
-#>
-######################################################################
-p6df::modules::jenkins::vscodes() {
-
-    # jenkins
-    p6df::modules::vscode::extension::install jmMeessen.jenkins-declarative-support
-
-    p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR
-#>
-######################################################################
-p6df::modules::jenkins::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/jenkinsfile-generator"            "$HOME/.claude/skills/jenkinsfile-generator"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/jenkinsfile-validator"            "$HOME/.claude/skills/jenkinsfile-validator"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::langs()
-#
-#>
-######################################################################
-p6df::modules::jenkins::langs() {
-
-    p6df::modules::jenkins::cli::get
-
-    p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::env::init()
-#
-#  Environment:	 JENKINS_HOST P6_JENKINS_HOST
-#>
 ######################################################################
 p6df::modules::jenkins::env::init() {
 
@@ -75,12 +17,6 @@ p6df::modules::jenkins::env::init() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::aliases::init()
-#
-#>
 ######################################################################
 p6df::modules::jenkins::aliases::init() {
 
@@ -95,13 +31,77 @@ p6df::modules::jenkins::aliases::init() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::profile::mod()
-#
-#>
+p6df::modules::jenkins::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/jenkinsfile-generator"            "$HOME/.claude/skills/jenkinsfile-generator"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/jenkinsfile-validator"            "$HOME/.claude/skills/jenkinsfile-validator"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::jenkins::langs() {
+
+    p6df::modules::jenkins::cli::get
+
+    p6_return_void
+}
+
+######################################################################
+p6df::modules::jenkins::vscodes() {
+
+    # jenkins
+    p6df::modules::vscode::extension::install jmMeessen.jenkins-declarative-support
+
+    p6_return_void
+}
+
 ######################################################################
 p6df::modules::jenkins::profile::mod() {
 
     p6_jenkins_prompt_info
 }
+######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::langs()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::env::init()
+#
+#  Environment:	 JENKINS_HOST P6_JENKINS_HOST
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::aliases::init()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::profile::mod()
+#
+#>

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::deps()
+#
+#>
+######################################################################
 p6df::modules::jenkins::deps() {
     ModuleDeps=(
         p6m7g8-dotfiles/p6df-java
@@ -7,6 +13,13 @@ p6df::modules::jenkins::deps() {
     )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::env::init()
+#
+#  Environment:	 JENKINS_HOST P6_JENKINS_HOST
+#>
 ######################################################################
 p6df::modules::jenkins::env::init() {
 
@@ -17,6 +30,12 @@ p6df::modules::jenkins::env::init() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::aliases::init()
+#
+#>
 ######################################################################
 p6df::modules::jenkins::aliases::init() {
 
@@ -31,6 +50,13 @@ p6df::modules::jenkins::aliases::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
 p6df::modules::jenkins::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/jenkinsfile-generator"            "$HOME/.claude/skills/jenkinsfile-generator"
@@ -40,6 +66,12 @@ p6df::modules::jenkins::home::symlinks() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::langs()
+#
+#>
+######################################################################
 p6df::modules::jenkins::langs() {
 
     p6df::modules::jenkins::cli::get
@@ -47,6 +79,12 @@ p6df::modules::jenkins::langs() {
     p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::jenkins::vscodes()
+#
+#>
 ######################################################################
 p6df::modules::jenkins::vscodes() {
 
@@ -57,51 +95,13 @@ p6df::modules::jenkins::vscodes() {
 }
 
 ######################################################################
-p6df::modules::jenkins::profile::mod() {
-
-    p6_jenkins_prompt_info
-}
-######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::langs()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::env::init()
-#
-#  Environment:	 JENKINS_HOST P6_JENKINS_HOST
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::jenkins::aliases::init()
-#
-#>
-######################################################################
 #<
 #
 # Function: p6df::modules::jenkins::profile::mod()
 #
 #>
+######################################################################
+p6df::modules::jenkins::profile::mod() {
+
+    p6_jenkins_prompt_info
+}


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None