### PR TITLE
chore(docs): fix aliases::init and env::init arg signatures in README and init.zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,18 @@ TODO: Add a short summary of this module.
 
 ##### p6df-jenkins/init.zsh
 
-- `p6df::modules::jenkins::aliases::init()`
-- `p6df::modules::jenkins::deps()`
-- `p6df::modules::jenkins::init(_module, dir)`
+- `p6df::modules::jenkins::aliases::init(_module, _dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - _dir
+- `p6df::modules::jenkins::deps()`
+- `p6df::modules::jenkins::env::init(_module, _dir)`
+  - Args:
+    - _module
+    - _dir
+- `p6df::modules::jenkins::home::symlinks()`
 - `p6df::modules::jenkins::langs()`
-- `p6df::modules::jenkins::prompt::mod()`
+- `p6df::modules::jenkins::profile::mod()`
 - `p6df::modules::jenkins::vscodes()`
 
 #### p6df-jenkins/lib

--- a/init.zsh
+++ b/init.zsh
@@ -16,7 +16,11 @@ p6df::modules::jenkins::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::jenkins::env::init()
+# Function: p6df::modules::jenkins::env::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #  Environment:	 JENKINS_HOST P6_JENKINS_HOST
 #>
@@ -33,7 +37,11 @@ p6df::modules::jenkins::env::init() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::jenkins::aliases::init()
+# Function: p6df::modules::jenkins::aliases::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #>
 ######################################################################


### PR DESCRIPTION
**What:** Add _module/_dir arg docs to aliases::init and env::init in both init.zsh comment blocks and README function list.

**Why:** Keep docs in sync with actual function signatures after recent refactor renaming init to env::init.

**Test plan:** Reviewed diff manually; changes are documentation and comment-block only.

**Dependencies:** none